### PR TITLE
Completed challenge

### DIFF
--- a/src/main/java/com/apiUtils/FlickrAPI.java
+++ b/src/main/java/com/apiUtils/FlickrAPI.java
@@ -1,0 +1,133 @@
+package com.apiUtils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flickr.FlickrTile;
+import com.flickr.Url;
+
+public class FlickrAPI {
+	
+	RestTemplate restTemplate = new RestTemplate();
+	
+	//constants
+	private static final int MAX_LENGTH  = 10;
+	private static final String base_url = "https://api.flickr.com/services/rest/";
+	private static final String api_key  = "80aafb8d5879b4ab3d58a6543021cd59";
+	
+	//enums for methods
+	public enum ApiMethods {
+		
+		SEARCH("flickr.photos.search"),
+		SIZE("flickr.photos.getSizes");
+
+	    private String method;
+
+	    ApiMethods(String method) {
+	        this.method = method;
+	    }
+	}
+	
+	/*
+	 * 1st arg: base_url
+	 * 2nd arg: method
+	 * 3rd arg: api_key
+	 * 4th arg: args (rest of arguments for API call)
+	 */
+	private static final String format = "%s?method=%s&api_key=%s&format=json&nojsoncallback=1%s";
+	
+	
+	/**
+	 * Retrieves an images sizes and urls
+	 * @param photoId
+	 * @return
+	 * @throws JsonProcessingException
+	 * @throws IOException
+	 */
+	public List<Url> fetchImageSize(String photoId) throws JsonProcessingException, IOException {
+		
+		ResponseEntity<String> response = fetchJsonFromSizeAPI(photoId);
+		JsonNode root = convertJsonToNodes(response);
+		JsonNode sizes = root.path("sizes").path("size");
+				
+		return createUrlList(sizes);
+	}
+	
+	
+	/**
+	 * Retrieves a list of names based on the search criteria
+	 * @return
+	 * @throws JsonProcessingException
+	 * @throws IOException
+	 */
+	public List<FlickrTile> fetchImageTitleAndIds(String query) throws JsonProcessingException, IOException {
+		
+		ResponseEntity<String> response = fetchJsonFromSearchAPI(query);
+		JsonNode root = convertJsonToNodes(response);
+		JsonNode photos = root.path("photos").path("photo");
+										
+		return createTileList(photos);
+	}
+	
+	
+	/*================HELPER FUNCTIONS====================*/
+	
+	
+	private ResponseEntity<String> fetchJsonFromSizeAPI(String photoId) {
+		
+		String url = String.format(format, base_url, ApiMethods.SIZE.method, api_key, "&photo_id=" + photoId);	
+		ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
+		
+		return response;
+	}
+	
+	
+	private ResponseEntity<String> fetchJsonFromSearchAPI(String query) {
+		
+		String url = String.format(format, base_url, ApiMethods.SEARCH.method, api_key, "&text=" + query);	
+		ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
+				
+		return response;
+	}
+	
+	
+	private JsonNode convertJsonToNodes(ResponseEntity<String> response) throws JsonProcessingException, IOException {	
+		
+		ObjectMapper mapper = new ObjectMapper();
+		JsonNode root = mapper.readTree(response.getBody());
+		
+		return root;
+	}
+	
+	
+	private List<FlickrTile> createTileList(JsonNode photos) {
+		
+		List<FlickrTile> dataList = new ArrayList<FlickrTile>();
+		
+		for(int i = 0; i < photos.size() && i < MAX_LENGTH; i++) {
+			FlickrTile tile = new FlickrTile(photos.get(i));
+			dataList.add(tile);
+		}
+		
+		return dataList;
+	}
+	
+	
+	private List<Url> createUrlList(JsonNode sizes) {
+		
+		List<Url> urls = new ArrayList<Url>();
+		
+		for(JsonNode size : sizes) {
+			urls.add(new Url(size));
+		}
+		
+		return urls;
+	}
+
+
+}

--- a/src/main/java/com/flickr/Application.java
+++ b/src/main/java/com/flickr/Application.java
@@ -1,0 +1,12 @@
+package com.flickr;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+	public static void main(String[] args) {
+		SpringApplication.run(Application.class, args);
+	}
+}

--- a/src/main/java/com/flickr/FlickrTile.java
+++ b/src/main/java/com/flickr/FlickrTile.java
@@ -1,0 +1,48 @@
+package com.flickr;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FlickrTile {
+	
+	private String id;
+    private String title;
+    private List<Url> urls;
+    
+	public FlickrTile(String title, List<Url> urls) {
+		this.title = title;
+		this.urls  = urls;
+	}
+	
+	public FlickrTile(JsonNode node) {
+		this.id    = node.get("id").asText();
+		this.title = node.get("title").asText();
+	}
+
+	public String getTitle() {
+		return title;
+	}
+	
+	public List<Url> getUrls() {
+		return urls;
+	}
+	
+    @JsonIgnore
+	public String getId() {
+		return id;
+	}
+
+	public void setUrls(List<Url> urls) {
+		this.urls = urls;
+	}
+
+	@Override
+	public String toString() {
+		return "FlickrTile [id=" + id + ", title=" + title + ", urls=" + urls + "]";
+	}
+
+}

--- a/src/main/java/com/flickr/FlickrTileController.java
+++ b/src/main/java/com/flickr/FlickrTileController.java
@@ -1,0 +1,54 @@
+package com.flickr;
+
+import java.io.IOException;
+import java.util.List;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import com.apiUtils.FlickrAPI;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+@RestController
+public class FlickrTileController {
+	
+	private FlickrAPI api = new FlickrAPI();
+	
+	@RequestMapping("/images")
+    public List<FlickrTile> images(@RequestParam(value="query") String query) {
+		
+		List<FlickrTile> flickrTiles = null;
+		
+		try {
+			flickrTiles = retrieveTilesFromFlickrApi(query);
+		}catch(Exception e) {
+			handleErrors(e);
+		}
+		
+        return flickrTiles;
+    }
+	
+    
+    private List<FlickrTile> retrieveTilesFromFlickrApi(String query) throws JsonProcessingException, IOException {
+    	
+    	List<FlickrTile> flickrTiles = api.fetchImageTitleAndIds(query);
+		    		
+		for(FlickrTile tile : flickrTiles) { 
+			tile.setUrls(api.fetchImageSize(tile.getId()));    			
+		}
+  	
+    	return flickrTiles;
+    	
+    }
+    
+    
+    //handle errors here
+    private void handleErrors(Exception e) {
+    	
+    	if(e instanceof IOException) {
+    		
+    	}else if(e instanceof JsonProcessingException) {
+    		
+    	}
+    }
+	
+}

--- a/src/main/java/com/flickr/Url.java
+++ b/src/main/java/com/flickr/Url.java
@@ -1,0 +1,40 @@
+package com.flickr;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class Url {
+	
+	private int width;
+	private int height;
+	private String url;
+	
+	public Url(int width, int height, String url) {
+		this.width  = width;
+		this.height = height;
+		this.url    = url;
+	}
+	
+	public Url(JsonNode node) {
+		this.width  = node.get("width").asInt();
+		this.height = node.get("height").asInt();
+		this.url    = node.get("url").asText();
+	}
+
+	public int getWidth() {
+		return width;
+	}
+
+	public int getHeight() {
+		return height;
+	}
+	
+	public String getUrl() {
+		return url;
+	}
+
+	@Override
+	public String toString() {
+		return "Url [url=" + url + ", width=" + width + ", height=" + height + "]";
+	}
+	
+}


### PR DESCRIPTION
PRO's of my approach:
- always up to date data because using Flickr's API every single time to retrieve results

CON's of my approach:
- every call to the service uses 2 Flickr API calls. If you are querying the same type of data multiple times it be better to cache the results instead of continually calling the API's over and over again
- currently only supports text argument of the flickr.photos.search API

Regarding alternative approaches I didn't really think of anything else besides caching the results from Flickr's API calls. I knew I needed to use the Search call to look retrieve the title and id from the photos and then pass in the ids into the Size API call to retrieve the width, height, and urls. From there all I needed to do was link the two separate return calls together.